### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:slim-buster
+RUN apt-get update && apt-get install -y flam3
+# TODO: clean up apt remanents
+WORKDIR /opt/electricsheep-hd-client
+COPY . .
+RUN bundle install
+CMD ['/opt/electricsheep-hd-client/daemon']


### PR DESCRIPTION
Create a Dockerfile, allowing the use of electricsheep-hd-client in server and headless contexts.

I would appreciate a review

TODO:
* Read API key from environment variable
* Use Xvfb or implement #73
* Figure how to handle the data directory

Unfortunately, I know ~0 ruby.